### PR TITLE
Add Windows Firestore emulator instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,104 @@
-# bpo_test2
+# Paper Operations Management Tool (MVP)
+
+This project demonstrates a minimal local-first setup for managing data entry and paper operations. It contains a Python backend built with Google Cloud Functions Framework and a React frontend.
+
+## Requirements
+- Python 3.9+
+- Node.js 16+
+- Docker (for Firestore emulator)
+
+## Docker Usage
+
+1. Install Docker Desktop or the Docker Engine for your OS.
+   Verify installation with `docker --version`.
+2. Pull the emulator image (optional, as `docker run` will pull automatically):
+   ```bash
+   docker pull google/cloud-sdk:emulators
+   ```
+3. Start the Firestore emulator container (leave this terminal running):
+   - **Linux/macOS**
+     ```bash
+     docker run --rm -it -p 8081:8080 google/cloud-sdk:emulators \
+       gcloud beta emulators firestore start --host-port=0.0.0.0:8080
+     ```
+   - **Windows (cmd.exe)**
+     ```cmd
+     docker run --rm -it -p 8081:8080 google/cloud-sdk:emulators ^
+       gcloud beta emulators firestore start --host-port=0.0.0.0:8080
+     ```
+     Make sure there is **no trailing space** after the caret (`^`).
+   The `--rm` flag cleans up the container when you stop it with `Ctrl+C`.
+   You can confirm it is running using `docker ps`.
+
+## Local Setup
+
+1. **Start the Firestore emulator** (leave this terminal running):
+    - **Linux/macOS**
+      ```bash
+      docker run --rm -it -p 8081:8080 google/cloud-sdk:emulators \
+        gcloud beta emulators firestore start --host-port=0.0.0.0:8080
+      ```
+    - **Windows (cmd.exe)**
+      ```cmd
+      docker run --rm -it -p 8081:8080 google/cloud-sdk:emulators ^
+        gcloud beta emulators firestore start --host-port=0.0.0.0:8080
+      ```
+      Again ensure no spaces follow the caret.
+
+2. **Install backend dependencies and run the Functions Framework:**
+    ```bash
+    cd backend
+    pip install -r requirements.txt
+    export GOOGLE_CLOUD_PROJECT=local-project
+    export BUCKET_NAME=receipt-images
+    functions-framework --target=app
+    ```
+
+On Windows `cmd.exe`, use `set` to define environment variables:
+```cmd
+set GOOGLE_CLOUD_PROJECT=local-project
+set BUCKET_NAME=receipt-images
+functions-framework --target=app
+```
+For PowerShell:
+```powershell
+$env:GOOGLE_CLOUD_PROJECT="local-project"
+$env:BUCKET_NAME="receipt-images"
+functions-framework --target=app
+```
+
+3. **Install frontend dependencies and start the React app:**
+    ```bash
+    cd ../frontend
+    npm install
+    REACT_APP_API_BASE=http://localhost:8080 npm start
+    ```
+
+On Windows `cmd.exe` run:
+```cmd
+set REACT_APP_API_BASE=http://localhost:8080
+npm start
+```
+For PowerShell:
+```powershell
+$env:REACT_APP_API_BASE='http://localhost:8080'
+npm start
+```
+    The development server runs at <http://localhost:3000>.
+
+4. **Verify the API** (optional example using `curl`):
+    ```bash
+    curl http://localhost:8080/receipts
+    ```
+
+Receipts created in the UI are stored in the Firestore emulator. Cloud Storage can be emulated locally in a similar manner if needed.
+
+## Running with Docker Compose
+
+As an alternative to running services manually, you can launch the backend and Firestore emulator together:
+
+```bash
+docker-compose up
+```
+
+The backend will be available on `http://localhost:8080` and the emulator on port `8081`. Use `docker-compose down` to stop all containers.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.9-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . ./
+ENV GOOGLE_CLOUD_PROJECT=local-project
+ENV BUCKET_NAME=receipt-images
+CMD ["functions-framework", "--target=app", "--port", "8080"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,113 @@
+from flask import Flask, jsonify, request
+from flask_cors import CORS
+from google.cloud import firestore, storage
+import uuid
+import os
+from datetime import datetime
+
+app = Flask(__name__)
+CORS(app)
+
+firestore_client = firestore.Client()
+storage_client = storage.Client()
+BUCKET_NAME = os.environ.get('BUCKET_NAME', 'receipt-images')
+
+@app.route('/receipts', methods=['POST'])
+def create_receipt():
+    try:
+        request_json = request.form if request.form else request.get_json(silent=True)
+        if request_json is None:
+            return jsonify({'error': 'Invalid request'}), 400
+        case_id = request_json.get('caseId')
+        receipt_id = request_json.get('receiptId') or str(uuid.uuid4())
+        receipt_type = request_json.get('receiptType')
+        quantity = request_json.get('quantity')
+        received_date = request_json.get('receivedDateTime')
+        assigned_to = request_json.get('assignedTo')
+        storage_location = request_json.get('storageLocation')
+        receipt_image = request.files.get('receiptImageFile') if request.files else None
+        data = {
+            'caseId': case_id,
+            'receiptId': receipt_id,
+            'receiptType': receipt_type,
+            'quantity': quantity,
+            'receivedDateTime': received_date,
+            'assignedTo': assigned_to,
+            'storageLocation': storage_location,
+            'status': 'Received',
+            'createdAt': datetime.utcnow().isoformat()
+        }
+        firestore_client.collection('receipts').document(receipt_id).set(data)
+        if receipt_image:
+            bucket = storage_client.bucket(BUCKET_NAME)
+            blob = bucket.blob(f"{receipt_id}/{receipt_image.filename}")
+            blob.upload_from_file(receipt_image.stream, content_type=receipt_image.content_type)
+            data['imageUrl'] = blob.public_url
+            firestore_client.collection('receipts').document(receipt_id).update({'imageUrl': data['imageUrl']})
+        return jsonify({'message': 'Receipt created', 'receiptId': receipt_id}), 201
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/receipts', methods=['GET'])
+def list_receipts():
+    try:
+        case_id = request.args.get('caseId') if request.args else None
+        receipts_ref = firestore_client.collection('receipts')
+        if case_id:
+            query = receipts_ref.where('caseId', '==', case_id)
+        else:
+            query = receipts_ref
+        docs = query.stream()
+        receipts = [doc.to_dict() for doc in docs]
+        return jsonify(receipts), 200
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/receipts/<receipt_id>', methods=['GET'])
+def get_receipt(receipt_id):
+    if not receipt_id:
+        return jsonify({'error': 'Missing receiptId'}), 400
+    try:
+        doc_ref = firestore_client.collection('receipts').document(receipt_id)
+        doc = doc_ref.get()
+        if not doc.exists:
+            return jsonify({'error': 'Receipt not found'}), 404
+        return jsonify(doc.to_dict()), 200
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/receipts/<receipt_id>', methods=['PUT'])
+def update_receipt(receipt_id):
+    if not receipt_id:
+        return jsonify({'error': 'Missing receiptId'}), 400
+    try:
+        request_json = request.get_json(silent=True)
+        if not request_json:
+            return jsonify({'error': 'Invalid request'}), 400
+        update_data = {k: v for k, v in request_json.items() if v is not None}
+        firestore_client.collection('receipts').document(receipt_id).update(update_data)
+        return jsonify({'message': 'Receipt updated'}), 200
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/reports/summary', methods=['GET'])
+def get_summary_report():
+    try:
+        receipts_ref = firestore_client.collection('receipts')
+        docs = receipts_ref.stream()
+        receipts = [d.to_dict() for d in docs]
+        total = len(receipts)
+        status_count = {}
+        assignee_count = {}
+        for r in receipts:
+            status = r.get('status', 'Unknown')
+            status_count[status] = status_count.get(status, 0) + 1
+            assignee = r.get('assignedTo') or r.get('currentAssignee')
+            if assignee:
+                assignee_count[assignee] = assignee_count.get(assignee, 0) + 1
+        return jsonify({'totalReceipts': total, 'statusCounts': status_count, 'processedPerAssignee': assignee_count}), 200
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8080)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+functions-framework
+google-cloud-firestore
+google-cloud-storage
+flask
+flask-cors

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  firestore:
+    image: google/cloud-sdk:emulators
+    command: gcloud beta emulators firestore start --host-port=0.0.0.0:8080
+    ports:
+      - "8081:8080"
+  backend:
+    build: ./backend
+    environment:
+      GOOGLE_CLOUD_PROJECT: local-project
+      BUCKET_NAME: receipt-images
+    ports:
+      - "8080:8080"
+    depends_on:
+      - firestore

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,28 @@
+# Frontend for Paper Operations Tool
+
+This directory contains the React Single Page Application used to interact with the backend.
+
+## Running Locally
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Start the development server (defaults to `http://localhost:3000`):
+   ```bash
+   REACT_APP_API_BASE=http://localhost:8080 npm start
+   ```
+
+On Windows `cmd.exe` use:
+```cmd
+set REACT_APP_API_BASE=http://localhost:8080
+npm start
+```
+For PowerShell:
+```powershell
+$env:REACT_APP_API_BASE='http://localhost:8080'
+npm start
+```
+
+The `REACT_APP_API_BASE` variable defines where API requests are sent. When running the backend with the Functions Framework the base URL should be `http://localhost:8080`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "paper-ops-tool",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "axios": "^1.4.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Paper Ops Tool</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+import ReceiptForm from './components/ReceiptForm';
+import ReceiptList from './components/ReceiptList';
+import SummaryDashboard from './components/SummaryDashboard';
+
+function App() {
+  const [selected, setSelected] = useState(null);
+  const [refresh, setRefresh] = useState(false);
+
+  const handleCreated = () => setRefresh(!refresh);
+
+  return (
+    <div className="App">
+      <h1>Paper Operations Tool</h1>
+      <ReceiptForm onCreated={handleCreated} />
+      <ReceiptList key={refresh} onSelect={setSelected} />
+      <SummaryDashboard />
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,27 @@
+import axios from 'axios';
+
+const API_BASE = process.env.REACT_APP_API_BASE || 'http://localhost:8080';
+
+export const createReceipt = (data) => {
+  return axios.post(`${API_BASE}/receipts`, data, {
+    headers: {
+      'Content-Type': 'multipart/form-data'
+    }
+  });
+};
+
+export const fetchReceipts = (params) => {
+  return axios.get(`${API_BASE}/receipts`, { params });
+};
+
+export const fetchReceipt = (id) => {
+  return axios.get(`${API_BASE}/receipts/${id}`);
+};
+
+export const updateReceipt = (id, data) => {
+  return axios.put(`${API_BASE}/receipts/${id}`, data);
+};
+
+export const fetchSummary = () => {
+  return axios.get(`${API_BASE}/reports/summary`);
+};

--- a/frontend/src/components/ReceiptForm.js
+++ b/frontend/src/components/ReceiptForm.js
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { createReceipt } from '../api';
+
+export default function ReceiptForm({ onCreated }) {
+  const [form, setForm] = useState({});
+  const [file, setFile] = useState(null);
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleFile = (e) => {
+    setFile(e.target.files[0]);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const data = new FormData();
+    Object.entries(form).forEach(([k, v]) => data.append(k, v));
+    if (file) data.append('receiptImageFile', file);
+    try {
+      await createReceipt(data);
+      setForm({});
+      setFile(null);
+      if (onCreated) onCreated();
+    } catch (err) {
+      alert('Error creating receipt');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input name="caseId" placeholder="Case ID" onChange={handleChange} />
+      <input name="receiptType" placeholder="Type" onChange={handleChange} />
+      <input name="quantity" placeholder="Quantity" onChange={handleChange} />
+      <input name="receivedDateTime" placeholder="Received Date" onChange={handleChange} />
+      <input name="assignedTo" placeholder="Assigned To" onChange={handleChange} />
+      <input name="storageLocation" placeholder="Storage Location" onChange={handleChange} />
+      <input type="file" onChange={handleFile} />
+      <button type="submit">Save</button>
+    </form>
+  );
+}

--- a/frontend/src/components/ReceiptList.js
+++ b/frontend/src/components/ReceiptList.js
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import { fetchReceipts } from '../api';
+
+export default function ReceiptList({ onSelect }) {
+  const [receipts, setReceipts] = useState([]);
+
+  const load = async () => {
+    const { data } = await fetchReceipts();
+    setReceipts(data);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Receipt ID</th>
+          <th>Case ID</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {receipts.map((r) => (
+          <tr key={r.receiptId} onClick={() => onSelect && onSelect(r.receiptId)}>
+            <td>{r.receiptId}</td>
+            <td>{r.caseId}</td>
+            <td>{r.status}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/src/components/SummaryDashboard.js
+++ b/frontend/src/components/SummaryDashboard.js
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import { fetchSummary } from '../api';
+
+export default function SummaryDashboard() {
+  const [summary, setSummary] = useState(null);
+
+  const load = async () => {
+    const { data } = await fetchSummary();
+    setSummary(data);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  if (!summary) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h3>Summary</h3>
+      <p>Total Receipts: {summary.totalReceipts}</p>
+      <h4>Status Counts</h4>
+      <ul>
+        {Object.entries(summary.statusCounts).map(([k, v]) => (
+          <li key={k}>{k}: {v}</li>
+        ))}
+      </ul>
+      <h4>Processed per Assignee</h4>
+      <ul>
+        {Object.entries(summary.processedPerAssignee).map(([k, v]) => (
+          <li key={k}>{k}: {v}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- clarify how to run the Firestore emulator on Windows and Linux
- add Windows commands for setting env vars when running the backend and frontend
- serve all endpoints from one Flask app with CORS support

## Testing
- `python3 -m py_compile backend/main.py`
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_684907c57dcc832eb1e19e7efd7d7f22